### PR TITLE
ios: process remote notifications

### DIFF
--- a/ios/meteocool/AppDelegate.swift
+++ b/ios/meteocool/AppDelegate.swift
@@ -10,13 +10,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         self.notificationManager = NotificationManager.init()
-
-        if let remoteNotification = launchOptions?[.remoteNotification] as?  [AnyHashable : Any] {
-            // Do what you want to happen when a remote notification is tapped.
-            print("Launch because of notification")
-        } else {
-            self.locationUpdater = LocationUpdater.init()
-        }
+        self.locationUpdater = LocationUpdater.init()
         return true
     }
 
@@ -44,8 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        print(userInfo)
-        if  let clear_all = userInfo["clear_all"] as? Bool {
+        if let clear_all = userInfo["clear_all"] as? Bool {
             if (clear_all) {
                 self.notificationManager.clearNotifications()
             }
@@ -59,12 +52,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let token = deviceToken.map { data -> String in
             return String(format: "%02.2hhx", data)
         }.joined()
-        print("Device Token: \(token)")
+        NSLog("Device Token: \(token)")
         locationUpdater.token = token
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("Failed to register for remote notifications with error: \(error)")
+        NSLog("Failed to register for remote notifications with error: \(error)")
     }
 }
 

--- a/ios/meteocool/AppDelegate.swift
+++ b/ios/meteocool/AppDelegate.swift
@@ -36,6 +36,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        print(userInfo)
+        if  let clear_all = userInfo["clear_all"] as? Bool {
+            if (clear_all) {
+                self.notificationManager.clearNotifications()
+            }
+        }
+    }
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {

--- a/ios/meteocool/AppDelegate.swift
+++ b/ios/meteocool/AppDelegate.swift
@@ -44,6 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 self.notificationManager.clearNotifications()
             }
         }
+        completionHandler(.newData)
     }
 }
 

--- a/ios/meteocool/AppDelegate.swift
+++ b/ios/meteocool/AppDelegate.swift
@@ -10,7 +10,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         self.notificationManager = NotificationManager.init()
-        self.locationUpdater = LocationUpdater.init()
+
+        if let remoteNotification = launchOptions?[.remoteNotification] as?  [AnyHashable : Any] {
+            // Do what you want to happen when a remote notification is tapped.
+            print("Launch because of notification")
+        } else {
+            self.locationUpdater = LocationUpdater.init()
+        }
         return true
     }
 

--- a/ios/meteocool/Info.plist
+++ b/ios/meteocool/Info.plist
@@ -31,6 +31,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ios/meteocool/Info.plist
+++ b/ios/meteocool/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/meteocool/Info.plist
+++ b/ios/meteocool/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/meteocool/lib/LocationUpdater.swift
+++ b/ios/meteocool/lib/LocationUpdater.swift
@@ -16,15 +16,15 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
         if CLLocationManager.locationServicesEnabled() {
             switch CLLocationManager.authorizationStatus() {
             case .notDetermined, .restricted, .denied:
-                print("Location: No access")
+                NSLog("Location: No access")
             case .authorizedWhenInUse:
-                print("Location: WhenInUse")
+                NSLog("Location: WhenInUse")
             case .authorizedAlways:
-                print("Location: Always")
+                NSLog("Location: Always")
                 startSignificantChangeLocationUpdates()
             }
         } else {
-            print("Location services are not enabled")
+            NSLog("Location services are not enabled")
         }
     }
 
@@ -48,7 +48,7 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print("CLLocationManager ERR: \(error)")
+        NSLog("CLLocationManager ERR: \(error)")
     }
 
     func postLocationDeferred(location: CLLocation) {
@@ -63,7 +63,7 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
 
     func postLocation(location: CLLocation) {
         guard let token = token else {
-            print("No token")
+            NSLog("No token")
             return
         }
 
@@ -88,7 +88,7 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
 
             if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] {
                 if let errorMessage = json?["error"] as? String {
-                    print("ERROR: \(errorMessage)")
+                    NSLog("ERROR: \(errorMessage)")
                 }
             }
         }

--- a/ios/meteocool/lib/NetworkHelper.swift
+++ b/ios/meteocool/lib/NetworkHelper.swift
@@ -13,7 +13,7 @@ class NetworkHelper {
     static func createJSONPostRequest(dst: String, dictionary: [String: Any]) -> URLRequest? {
         let json = try! JSONSerialization.data(withJSONObject: dictionary)
         if let jsonString = String(data: json, encoding: .utf8), debug {
-            print("POST: /\(String(describing: dst)) <- \(jsonString)")
+            NSLog("POST: /\(String(describing: dst)) <- \(jsonString)")
         }
 
         var request = createRequest(dst: dst, method: "POST")
@@ -25,18 +25,18 @@ class NetworkHelper {
 
     static func checkResponse(data: Data?, response: URLResponse?, error: Error?) -> Data? {
         guard let data = data, error == nil else {
-            print("ERROR: \(String(describing: error))")
+            NSLog("ERROR: \(String(describing: error))")
             return nil
         }
 
         let dst = response?.url?.path ?? ""
         if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != 200 {
-            print("RESP: \(String(describing: dst)) -> \(httpStatus.statusCode)")
+            NSLog("RESP: \(String(describing: dst)) -> \(httpStatus.statusCode)")
             return nil
         }
         if let responseString = String(data: data, encoding: .utf8) {
             if (debug) {
-                print("RESP: \(String(describing: dst)) -> \(responseString)")
+                NSLog("RESP: \(String(describing: dst)) -> \(responseString)")
             }
         }
         return data

--- a/ios/meteocool/lib/NotificationManager.swift
+++ b/ios/meteocool/lib/NotificationManager.swift
@@ -11,7 +11,7 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         UNUserNotificationCenter.current().delegate = self
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
             (granted, error) in
-            print("Permission granted: \(granted)")
+            NSLog("Permission granted: \(granted)")
             guard granted else { return }
             DispatchQueue.main.async {
                 UIApplication.shared.registerForRemoteNotifications()


### PR DESCRIPTION
This allows us to receive so called "silent push" notifications. We
use those to clear any pending notification if it was not acknowledged
before the rain stopped. No use in displaying and accumulating
notifications of past rain.