### PR TITLE
ios: altimeter measurements

### DIFF
--- a/ios/NotificationContent/Info.plist
+++ b/ios/NotificationContent/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>14</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ios/NotificationService/Info.plist
+++ b/ios/NotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>14</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/meteocool/AppDelegate.swift
+++ b/ios/meteocool/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import UserNotifications
+import CoreMotion
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -7,6 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var notificationManager: NotificationManager!
     var locationUpdater: LocationUpdater!
     var pushToken: String?
+    lazy var altimeter = CMAltimeter()
+    var pressure: Double = 0.0
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -30,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.notificationManager.clearNotifications()
         // XXX call this only when there are >0 notifications on launch!
         acknowledgeNotification(retry: true, from: "foreground")
-
+        self.locationUpdater.locationManager.requestLocation()
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {

--- a/ios/meteocool/Info.plist
+++ b/ios/meteocool/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/meteocool/lib/LocationUpdater.swift
+++ b/ios/meteocool/lib/LocationUpdater.swift
@@ -1,13 +1,21 @@
 import UIKit
 import CoreLocation
+import CoreMotion
+
+let NUM_PRESSURE_MEASUREMENTS = 3
 
 class LocationUpdater: NSObject, CLLocationManagerDelegate {
     let locationManager: CLLocationManager
+    lazy var altimeter = CMAltimeter()
     let deviceID: String = UIDevice.current.identifierForVendor!.uuidString
     var token: String?
+    var averagePressure: Double
+    var pressureMeasurements: Int
 
     override init() {
         locationManager = CLLocationManager()
+        averagePressure = 0
+        pressureMeasurements = 0
         super.init()
 
         locationManager.delegate = self
@@ -35,7 +43,7 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
 
     func startBackgroundLocationUpdates() {
         self.locationManager.allowsBackgroundLocationUpdates = true
-        self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+        self.locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
         self.locationManager.pausesLocationUpdatesAutomatically = true
         self.locationManager.activityType = CLActivityType.other
         self.locationManager.startUpdatingLocation()
@@ -43,7 +51,40 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.last {
-            self.postLocationDeferred(location:location)
+            if (CMAltimeter.isRelativeAltitudeAvailable()) {
+                // we have a location fix, now read a few values from the altimeter
+                self.averagePressure = 0
+                self.pressureMeasurements = 0
+                self.altimeter.startRelativeAltitudeUpdates(to: OperationQueue.main, withHandler: { (altitudeData:CMAltitudeData?, error:Error?) in
+                    if (error != nil) {
+                        self.altimeter.stopRelativeAltitudeUpdates()
+                        return
+                    }
+                    // not sure if necessary to avoid processing old OperationQueue items.
+                    if (self.pressureMeasurements >= NUM_PRESSURE_MEASUREMENTS) {
+                        return
+                    }
+
+                    // average over the last n measurements
+                    // XXX time will tell if this is really necessary... the altimeter is very accurate, so it might not be necessary
+                    // to take an average. remove if battery usage is a concern.
+                    let measurement = altitudeData!.pressure.doubleValue * 10
+                    if (self.pressureMeasurements == 0) {
+                        self.averagePressure = measurement
+                    } else {
+                        self.averagePressure = (self.averagePressure + measurement) / 2
+                    }
+                    self.pressureMeasurements += 1
+
+                    if (self.pressureMeasurements == NUM_PRESSURE_MEASUREMENTS) {
+                        NSLog("Average pressure (%d measurements): %f", NUM_PRESSURE_MEASUREMENTS, self.averagePressure)
+                        self.altimeter.stopRelativeAltitudeUpdates()
+                        self.postLocationDeferred(location: location, pressure: self.averagePressure)
+                    }
+                })
+            } else {
+                self.postLocationDeferred(location:location, pressure: -1)
+            }
         }
     }
 
@@ -51,30 +92,33 @@ class LocationUpdater: NSObject, CLLocationManagerDelegate {
         NSLog("CLLocationManager ERR: \(error)")
     }
 
-    func postLocationDeferred(location: CLLocation) {
+    func postLocationDeferred(location: CLLocation, pressure: Double) {
         if token != nil {
-            postLocation(location: location)
+            postLocation(location: location, pressure: pressure)
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(4), execute: {
-                self.postLocation(location: location)
+                self.postLocation(location: location, pressure: pressure)
             })
         }
     }
 
-    func postLocation(location: CLLocation) {
-        guard let token = token else {
-            NSLog("No token")
-            return
-        }
+    func postLocation(location: CLLocation, pressure: Double) {
+        let tokenValue = self.token ?? "anon";
 
         let locationDict = [
             "lat": location.coordinate.latitude as Double,
             "lon": location.coordinate.longitude as Double,
+            "altitude": location.altitude as Double,
             "accuracy": location.horizontalAccuracy as Double,
+            "verticalAccuracy": location.verticalAccuracy as Double,
+            "speed": location.speed as Double,
+            "course": location.course as Double,
+            "pressure": pressure,
+            "timestamp": location.timestamp.timeIntervalSince1970 as Double,
             "ahead": 15,
             "intensity": 10,
             "source" : "ios",
-            "token" : token,
+            "token" : tokenValue,
             ] as [String : Any]
 
         guard let request = NetworkHelper.createJSONPostRequest(dst: "post_location", dictionary: locationDict) else {


### PR DESCRIPTION
Report alimeter measurements to the backend, even if push is not
configured.

If push is enabled, this will also increase the accuracy if the app has
been launched after receiving a notification because we now re-request
the location update handler explicitly.