### PR TITLE
Modified RUN statement to not use cache

### DIFF
--- a/backend/app/Dockerfile
+++ b/backend/app/Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.6-alpine
 ADD requirements.txt /usr/src/app/requirements.txt
 WORKDIR /usr/src/app
 RUN apk --update add --virtual build-dependencies build-base \
-    && pip install -r requirements.txt \
-    && apk del build-dependencies && apk add vim bash
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del build-dependencies && apk add vim bash \
+    && rm -rf /var/cache/apk/*
 COPY . /usr/src/app
 EXPOSE 5000
 CMD ["sh", "/usr/src/app/start.sh"]


### PR DESCRIPTION
adding some flags to apk and pip disables the cache thus resulting in smaller docker image size